### PR TITLE
fix: react reference error

### DIFF
--- a/examples/nextjs-dapp/src/pages/index.tsx
+++ b/examples/nextjs-dapp/src/pages/index.tsx
@@ -3,8 +3,8 @@ import { FutureTapeButton } from '@public-assembly/future-tape'
 function Page() {
   return (
     <section className="flex flex-col gap-4">
-      <FutureTapeButton href="tag/present+material" />
-      <FutureTapeButton href="tag/present+material" color="pink" />
+      <FutureTapeButton href="present+material" />
+      <FutureTapeButton href="present+material" color="pink" />
     </section>
   )
 }

--- a/packages/future-tape/src/components/FutureTapeButton.tsx
+++ b/packages/future-tape/src/components/FutureTapeButton.tsx
@@ -1,3 +1,5 @@
+import React from 'React'
+
 export type FutureTapeButtonProps = {
   /**
    * Class name to override styles on the link
@@ -29,9 +31,12 @@ export type FutureTapeButtonProps = {
 
 const FUTURE_TAPE_ADDRESS = 'https://futuretape.xyz/tag/'
 
-export function FutureTapeButton(props: FutureTapeButtonProps) {
-  const { className, text = 'Listen on Future Tape ↗︎', href, color = 'black' } = props
-
+export const FutureTapeButton: React.FC<FutureTapeButtonProps> = ({
+  text = 'Listen on Future Tape ↗︎',
+  color = 'black',
+  className,
+  href,
+}) => {
   return (
     <a
       className={

--- a/packages/future-tape/src/components/FutureTapeButton.tsx
+++ b/packages/future-tape/src/components/FutureTapeButton.tsx
@@ -1,5 +1,3 @@
-import React from 'React'
-
 export type FutureTapeButtonProps = {
   /**
    * Class name to override styles on the link

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "incremental": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "lib": ["es2019", "es2017", "dom"],
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
Getting a `ReferenceError: React is not defined` when importing the package into Present Material.

Used React as peer dep and forgot to use React in the package. so updated the types.

Watched Dain's loom and saw he ran into same problem lmao. 